### PR TITLE
Update extension manifest to version 3

### DIFF
--- a/Chrome_extension/src/background.js
+++ b/Chrome_extension/src/background.js
@@ -35,7 +35,9 @@ chrome.runtime.onMessage.addListener(function (req, sender, sendResponse) {
             return true;
         }
         case "altWatcherIsEnabled": {
-            sendResponse(localStorage.getItem('altWatcher'));
+            chrome.storage.local.get(['altWatcher'], function(result) {
+                sendResponse(result.altWatcher || null);
+            });
             return true;
         }
         case "altWatcherLinkUsed": {

--- a/Chrome_extension/src/manifest.json
+++ b/Chrome_extension/src/manifest.json
@@ -1,20 +1,28 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "Shiki extender",
   "description": "",
   "version": "1.0.2",
-  "options_page": "index.html#options",
+  "options_ui": {
+    "page": "index.html#options"
+  },
   
   "permissions": [
     "unlimitedStorage"
   ],
 
   "web_accessible_resources": [
-    "*.js.map",
-    "http://185.189.13.136"
+    {
+      "resources": ["*.js.map"],
+      "matches": ["*://shikimori.one/*", "*://shikimori.org/*"]
+    },
+    {
+      "resources": ["http://185.189.13.136"],
+      "matches": ["*://shikimori.one/*", "*://shikimori.org/*"]
+    }
   ],
 
-  "browser_action": {
+  "action": {
     "default_title": "Shiki extender",
     "default_popup": "index.html#options?popup=true"
   },
@@ -31,10 +39,7 @@
     }
   ],
 
-
   "background": {
-    "scripts": [
-      "background-bundle.js"
-    ]
+    "service_worker": "background-bundle.js"
   }
 }

--- a/Chrome_extension/src/manifest.json
+++ b/Chrome_extension/src/manifest.json
@@ -8,7 +8,8 @@
   },
   
   "permissions": [
-    "unlimitedStorage"
+    "unlimitedStorage",
+    "storage"
   ],
 
   "web_accessible_resources": [


### PR DESCRIPTION
Update Chrome extension to Manifest V3 and adapt background script for service worker compatibility.

The transition to Manifest V3 is mandatory for new Chrome extensions and brings security and performance improvements. The background script was updated to use `chrome.storage.local` as `localStorage` is not available in service workers.